### PR TITLE
Use csie domain instead of aws domain. Using ssl-sonarqube(temparory)

### DIFF
--- a/public/keycloak.json
+++ b/public/keycloak.json
@@ -1,6 +1,6 @@
 {
   "realm": "OIS",
-  "auth-server-url": "https://keycloak-beta.hsiang.me/auth/",
+  "auth-server-url": "https://ssl-sonarqube.csie.ntut.edu.tw/auth/",
   "ssl-required": "external",
   "resource": "timelog",
   "public-client": true,


### PR DESCRIPTION
To fix for users in Taipei Tech cannot use AWS DNS normally, I change to a domain from NTUT CSIE. 

New AMS domain: ssl-sonarqube.csie.ntut.edu.tw
Using this domain is just for now, will change to a better one after the application. 